### PR TITLE
Cmake hepmc additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,29 @@
 *.exe
 *.out
 *.app
+
+# Mac
+.DS_Store
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# --> Build
+build
+cmake-build-*/
+
+# ignore JetBrains ide project folder
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+.idea/
+
+
+

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -28,7 +28,11 @@ include(${Geant4_USE_FILE})
 # You can set eAST_USE_HepMC3 to OFF via the command line or ccmake/cmake-gui
 option(eAST_USE_HepMC3 "Build example with HepMC support, requires HepMC3" ON)
 if(eAST_USE_HepMC3)
+  message ( "---- You can specify a HepMC3 installation using \"-DHepMC3=[path/to/lib]\" " )
   find_package(HepMC3 REQUIRED HINTS ${HepMC3_DIR} ${HepMC3} )
+  message ( "-- HepMC3 library found at ${HEPMC3_LIB}" )
+  # message ( "-- HepMC3 headers found in ${HEPMC3_INCLUDE_DIR}" )
+  add_definitions(-DeAST_USE_HepMC3)
 endif()
 
 #----------------------------------------------------------------------------
@@ -55,18 +59,23 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh
                   )
 
 # In order to keep using glob, we have to manually remove optional sources
-if( NOT eAST_USE_HepMC3)
+if(eAST_USE_HepMC3)
+  include_directories ( ${HEPMC3_INCLUDE_DIR} )
+else()
   list(REMOVE_ITEM sources "src/HepmcDummy.cc")
   list(REMOVE_ITEM headers "include/HepmcDummy.hh")
 endif()
 		
-		
 #----------------------------------------------------------------------------
-# Add the executable, and link it to the Geant4 libraries
+# Add the executable, and link it to external libraries
 #
 add_executable(eAST eAST.cc ${sources} ${headers})
-target_link_libraries(eAST ${Geant4_LIBRARIES})
-
+if(eAST_USE_HepMC3)
+  target_link_libraries(eAST ${Geant4_LIBRARIES}  ${HEPMC3_LIB} )
+else()
+  target_link_libraries(eAST ${Geant4_LIBRARIES})
+endif()
+  
 #----------------------------------------------------------------------------
 # Copy all scripts to the build directory, i.e. the directory in which we
 # build RS. This is so that we can run the executable directly because it

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -96,7 +96,21 @@ endforeach()
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
-install(TARGETS eAST DESTINATION bin)
+install(TARGETS eAST
+  EXPORT east-export
+  DESTINATION bin)
 # Below should go into share?
 install(FILES DESTINATION bin)
+
+#----------------------------------------------------------------------------
+## Generate and install cmake configuration file
+install(EXPORT east-export
+  FILE
+    eastConfig.cmake
+  NAMESPACE
+    east::
+  DESTINATION
+  cmake
+  )
+
 

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,10 +1,10 @@
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8)
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
-project(eAST)
+project(eAST VERSION 0.1.0)
 
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
@@ -23,6 +23,13 @@ endif()
 # Setup include directory for this project
 #
 include(${Geant4_USE_FILE})
+
+#----------------------------------------------------------------------------
+# You can set eAST_USE_HepMC3 to OFF via the command line or ccmake/cmake-gui
+option(eAST_USE_HepMC3 "Build example with HepMC support, requires HepMC3" ON)
+if(eAST_USE_HepMC3)
+  find_package(HepMC3 REQUIRED HINTS ${HepMC3_DIR} ${HepMC3} )
+endif()
 
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
@@ -47,6 +54,13 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh
                   ${PROJECT_SOURCE_DIR}/../Components/Beampipe/include/*.hh
                   )
 
+# In order to keep using glob, we have to manually remove optional sources
+if( NOT eAST_USE_HepMC3)
+  list(REMOVE_ITEM sources "src/HepmcDummy.cc")
+  list(REMOVE_ITEM headers "include/HepmcDummy.hh")
+endif()
+		
+		
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries
 #

--- a/Core/include/HepmcDummy.hh
+++ b/Core/include/HepmcDummy.hh
@@ -1,0 +1,10 @@
+#ifndef HEPMCDUMMY_H_
+#define HEPMCDUMMY_H_
+
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenVertex.h>
+#include <HepMC3/GenParticle.h>
+
+void HepMCDummyFunction( const HepMC3::GenParticlePtr& p, std::unique_ptr<erhic::EventHepMC>& mEvent );
+
+#endif  // HEPMCDUMMY_H_

--- a/Core/include/HepmcDummy.hh
+++ b/Core/include/HepmcDummy.hh
@@ -5,6 +5,6 @@
 #include <HepMC3/GenVertex.h>
 #include <HepMC3/GenParticle.h>
 
-void HepMCDummyFunction( const HepMC3::GenParticlePtr& p, std::unique_ptr<erhic::EventHepMC>& mEvent );
+void HepMCDummyFunction( const HepMC3::GenParticlePtr& p );
 
 #endif  // HEPMCDUMMY_H_

--- a/Core/src/HepmcDummy.cc
+++ b/Core/src/HepmcDummy.cc
@@ -1,9 +1,14 @@
-#include "HepmcDummy.cc"
+#include "HepmcDummy.hh"
 
-
-void HepMCDummyFunction( const HepMC3::GenParticlePtr& p, std::unique_ptr<erhic::EventHepMC>& mEvent ){
+void HepMCDummyFunction( const HepMC3::GenParticlePtr& p ){
   // do nothing, essentially
   auto v = p->production_vertex();
-  auto e = mEvent.get();
   return;
+
+#ifdef eAST_USE_HepMC3
+  // all is well
+#else
+  generating a compile time error here, this should never happen;
+#endif
+  
 }

--- a/Core/src/HepmcDummy.cc
+++ b/Core/src/HepmcDummy.cc
@@ -1,0 +1,9 @@
+#include "HepmcDummy.cc"
+
+
+void HepMCDummyFunction( const HepMC3::GenParticlePtr& p, std::unique_ptr<erhic::EventHepMC>& mEvent ){
+  // do nothing, essentially
+  auto v = p->production_vertex();
+  auto e = mEvent.get();
+  return;
+}


### PR DESCRIPTION
Added HepMC functionality to cmake. Can be turned off by providing
```
-DeAST_USE_HepMC3=OFF
```
src/HepmcDummy.cc and include/HepmcDummy.hh, are for testing and to demonstrate that guarding using 
```
#ifdef eAST_USE_HepMC3
```
works. 

Cmake is pretty clever, but if you have trouble finding HepMC, make sure that ``CMAKE_MODULE_PATH`` contains the path to where cmake configurations are installed

Also added cmake configuration installation for eAST. 
