### PR TITLE
Bugfixes: Memory leak addressing

### DIFF
--- a/Core/include/eASTMagneticField.hh
+++ b/Core/include/eASTMagneticField.hh
@@ -64,6 +64,7 @@ class eASTMagneticFieldMap {
   private:
 
     // Field messenger
+    G4UIdirectory fFieldMapDirectory;
     G4GenericMessenger fFieldMapMessenger;
 
   private:
@@ -172,7 +173,7 @@ class eASTMagneticField : public G4MagneticField {
   public:
 
     eASTMagneticField();
-    ~eASTMagneticField() = default;
+    virtual ~eASTMagneticField();
 
     // Activate in ConstuctSDandField
     void Activate();
@@ -200,6 +201,7 @@ class eASTMagneticField : public G4MagneticField {
   private:
 
     // Field messenger
+    G4UIdirectory fFieldDirectory;
     G4GenericMessenger fFieldMessenger;
 
   private:

--- a/Core/src/eAInitialization.cc
+++ b/Core/src/eAInitialization.cc
@@ -62,6 +62,9 @@ eAInitialization::eAInitialization(G4int verboseLvl)
 
 eAInitialization::~eAInitialization()
 {
+  delete field;
+  delete physics;
+  delete detector;
   delete messenger; 
 }
 


### PR DESCRIPTION
This addresses a few memory leaks:
- delete gorad objects in initialization destructor,
- create directories for each (magnetic field) messenger,
- create equation, stepper, chordfinder in magnetic field constructor, and delete in destructor.

Comments:
- Creating an explicit directory before creating a messenger in it is not actually solving the memory leak in G4GenericMessenger.cc:L63, but it's the closest to something that may work in the future. The only memory issues left related to eASTMagneticField are these...
- G4UIdirectory doesn't have a constructor from G4String, which is why this requires a c_str() for a non-const G4String.