### PR TITLE
workflows: build explicitly on ubuntu-20.04

### DIFF
--- a/.github/workflows/build_with_lcg_on_cvmfs.yml
+++ b/.github/workflows/build_with_lcg_on_cvmfs.yml
@@ -4,13 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_99/x86_64-centos7-clang10-opt",
-              "LCG_99/x86_64-centos7-gcc10-opt",
-              "LCG_99/x86_64-centos8-gcc10-opt",
+        LCG: ["LCG_101/x86_64-ubuntu2004-gcc9-opt",
               "LCG_99/x86_64-ubuntu2004-gcc9-opt"]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is more stable than relying on `-latest` not changing...