### PR TITLE
Fixing eASTGammaLeptoNuclearPhysics.cc

### DIFF
--- a/PhysicsList/Base/README.rst
+++ b/PhysicsList/Base/README.rst
@@ -4,8 +4,8 @@ eAST baseline Physics List
 **eAST baseline Physics List** is the baseline physics list for all the EIC detector components.
 Extensions can be applied to corresponding detector component(s).
 
-The current version works with Geant4 version 10.7-patch02. It also works with versions 10.7-patch01 and 10.7 but does not work with
-earlier versions of Geant4.
+The current version works with Geant4 version 11.0-patch02.
+It also works with versions 10.7-patch02 but does not work with earlier versions of Geant4.
 
 Description will be added here.
 
@@ -15,3 +15,6 @@ History
 05/14/2021 : First commit - Makoto Asai (SLAC)
 
 08/16/2021 : Fix pion cross-section - Makoto Asai (SLC)
+
+08/08/2022 : Fix eASTGammaLeptoNuclearPhysics.cc - Makoto Asai (JLab)
+

--- a/PhysicsList/Base/src/eASTGammaLeptoNuclearPhysics.cc
+++ b/PhysicsList/Base/src/eASTGammaLeptoNuclearPhysics.cc
@@ -77,10 +77,6 @@ void eASTGammaLeptoNuclearPhysics::ConstructProcess()
   qgsp->SetMinEnergy(3*GeV);
   qgsp->SetMaxEnergy(100*TeV);
 
-  // Lepto-nuclear models
-  G4ElectroVDNuclearModel* evdn = new G4ElectroVDNuclearModel;
-  G4MuonVDNuclearModel* mvdn = new G4MuonVDNuclearModel;
-
 
   G4ProcessManager* procMan = 0;
 
@@ -103,6 +99,10 @@ void eASTGammaLeptoNuclearPhysics::ConstructProcess()
 //  procMan->AddDiscreteProcess(photonCapture);
 //  procMan->AddDiscreteProcess(photonFission);
 //#endif
+
+  // Lepto-nuclear models
+  G4ElectroVDNuclearModel* evdn = new G4ElectroVDNuclearModel;
+  G4MuonVDNuclearModel* mvdn = new G4MuonVDNuclearModel;
 
   // Electron
   procMan = G4Electron::Electron()->GetProcessManager();


### PR DESCRIPTION
Correct the order of instantiating G4ElectroVDNuclearModel and G4MuonVDNuclearModel. They must be instantiated after G4PhotoNuclearCrossSection.